### PR TITLE
Implement $concat preprocessing support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,6 @@
             "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
@@ -611,7 +610,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -1184,7 +1182,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.9",
                 "caniuse-lite": "^1.0.30001746",
@@ -3134,7 +3131,6 @@
             "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
             "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
@@ -610,6 +611,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -1182,6 +1184,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.9",
                 "caniuse-lite": "^1.0.30001746",
@@ -3131,6 +3134,7 @@
             "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },

--- a/src/ergogen.js
+++ b/src/ergogen.js
@@ -28,6 +28,7 @@ const process = async (raw, options={}, logger=()=>{}) => {
     config = prepare.unnest(config)
     config = prepare.inherit(config)
     config = prepare.parameterize(config)
+    config = prepare.concat(config)
     const results = {}
     if (debug) {
         results.raw = raw

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -180,59 +180,70 @@ const parseArgs = (inner) => {
     let depth = 0
     let inQuote = false
     let quoteChar = ''
-
     for (let i = 0; i < inner.length; i++) {
         const char = inner[i]
-        if (inQuote) {
-            current += char
-            if (char === quoteChar && inner[i - 1] !== '\\') {
-                inQuote = false
-            }
-        } else {
-            if (char === "'" || char === '"') {
+        if ((char === '"' || char === "'") && (i === 0 || inner[i-1] !== '\\')) {
+            if (!inQuote) {
                 inQuote = true
                 quoteChar = char
                 current += char
-            } else if (char === '(') {
-                depth++
+            } else if (char === quoteChar) {
+                inQuote = false
                 current += char
-            } else if (char === ')') {
-                depth--
-                current += char
-            } else if (char === ',' && depth === 0) {
-                args.push(current.trim())
-                current = ''
             } else {
                 current += char
             }
+        } else if (!inQuote && char === '(') {
+            depth++
+            current += char
+        } else if (!inQuote && char === ')') {
+            depth--
+            current += char
+        } else if (!inQuote && char === ',' && depth === 0) {
+            args.push(current.trim())
+            current = ''
+        } else {
+            current += char
         }
     }
-    args.push(current.trim())
+    if (current.trim().length > 0 || inner.length === 0) {
+        args.push(current.trim())
+    }
     return args
 }
 
-const resolve = (val, root, breadcrumbs, seen = []) => {
-    if (typeof val !== 'string' || !val.startsWith('$concat(') || !val.endsWith(')')) return val
+const resolve = (val, root, breadcrumbs, seen = new Set()) => {
+    if (a.type(val)() !== 'string') return val
+    if (!val.startsWith('$concat(') || !val.endsWith(')')) return val
 
-    a.assert(!seen.includes(val), `"${breadcrumbs.join('.')}" Circular dependency!`)
-    seen.push(val)
+    if (seen.has(val)) {
+        throw new Error(`Circular dependency detected in $concat at "${breadcrumbs.join('.')}": ${val}`)
+    }
+    seen.add(val)
 
     const inner = val.substring(8, val.length - 1)
     const args = parseArgs(inner)
-    let res = ''
-    for (const arg of args) {
-        if (!arg) continue
-        if ((arg.startsWith("'") && arg.endsWith("'")) || (arg.startsWith('"') && arg.endsWith('"'))) {
-            res += arg.substring(1, arg.length - 1).replace(/\\'/g, "'").replace(/\\"/g, '"')
-        } else if (arg.startsWith('$concat(')) {
-            res += resolve(arg, root, breadcrumbs, seen)
-        } else {
+
+    const res = args
+        .filter(arg => arg.length > 0)
+        .map(arg => {
+            // String literal
+            if ((arg.startsWith('"') && arg.endsWith('"')) || (arg.startsWith("'") && arg.endsWith("'"))) {
+                return arg.substring(1, arg.length - 1).replace(/\\(.)/g, '$1')
+            }
+            // $concat call
+            if (arg.startsWith('$concat(')) {
+                return resolve(arg, root, breadcrumbs, seen)
+            }
+            // Reference
             const ref = u.deep(root, arg)
-            a.assert(ref !== undefined, `"${arg}" (referenced in $concat at "${breadcrumbs.join('.')}") Could not resolve reference!`)
-            res += resolve(ref, root, arg.split('.'), seen)
-        }
-    }
-    seen.pop()
+            if (ref === undefined) {
+                throw new Error(`Could not resolve reference "${arg}" in $concat at "${breadcrumbs.join('.')}"`)
+            }
+            return resolve(ref, root, breadcrumbs, seen)
+        }).join('')
+
+    seen.delete(val)
     return res
 }
 

--- a/src/prepare.js
+++ b/src/prepare.js
@@ -173,3 +173,69 @@ exports.parameterize = config => traverse(config, config, [], (target, key, val,
     delete val.$args
     target[key] = val
 })
+
+const parseArgs = (inner) => {
+    const args = []
+    let current = ''
+    let depth = 0
+    let inQuote = false
+    let quoteChar = ''
+
+    for (let i = 0; i < inner.length; i++) {
+        const char = inner[i]
+        if (inQuote) {
+            current += char
+            if (char === quoteChar && inner[i - 1] !== '\\') {
+                inQuote = false
+            }
+        } else {
+            if (char === "'" || char === '"') {
+                inQuote = true
+                quoteChar = char
+                current += char
+            } else if (char === '(') {
+                depth++
+                current += char
+            } else if (char === ')') {
+                depth--
+                current += char
+            } else if (char === ',' && depth === 0) {
+                args.push(current.trim())
+                current = ''
+            } else {
+                current += char
+            }
+        }
+    }
+    args.push(current.trim())
+    return args
+}
+
+const resolve = (val, root, breadcrumbs, seen = []) => {
+    if (typeof val !== 'string' || !val.startsWith('$concat(') || !val.endsWith(')')) return val
+
+    a.assert(!seen.includes(val), `"${breadcrumbs.join('.')}" Circular dependency!`)
+    seen.push(val)
+
+    const inner = val.substring(8, val.length - 1)
+    const args = parseArgs(inner)
+    let res = ''
+    for (const arg of args) {
+        if (!arg) continue
+        if ((arg.startsWith("'") && arg.endsWith("'")) || (arg.startsWith('"') && arg.endsWith('"'))) {
+            res += arg.substring(1, arg.length - 1).replace(/\\'/g, "'").replace(/\\"/g, '"')
+        } else if (arg.startsWith('$concat(')) {
+            res += resolve(arg, root, breadcrumbs, seen)
+        } else {
+            const ref = u.deep(root, arg)
+            a.assert(ref !== undefined, `"${arg}" (referenced in $concat at "${breadcrumbs.join('.')}") Could not resolve reference!`)
+            res += resolve(ref, root, arg.split('.'), seen)
+        }
+    }
+    seen.pop()
+    return res
+}
+
+exports.concat = config => traverse(config, config, [], (target, key, val, root, breadcrumbs) => {
+    target[key] = resolve(val, root, breadcrumbs)
+})

--- a/test/unit/prepare.js
+++ b/test/unit/prepare.js
@@ -171,6 +171,13 @@ describe('Prepare', function() {
             extended: { $extends: 'base' }
         }
         p.inherit(config_arr_inh).extended.should.deep.equal([1, 2])
+
+        // Inheritance of non-object/non-array types
+        const config_primitive_inh = {
+            base: 'primitive',
+            extended: { $extends: 'base' }
+        }
+        p.inherit(config_primitive_inh).extended.should.equal('primitive')
     })
 
     it('parameterize', function() {

--- a/test/unit/prepare.js
+++ b/test/unit/prepare.js
@@ -232,4 +232,81 @@ describe('Prepare', function() {
             }
         }).should.throw('valid')
     })
+
+    it('concat', function() {
+        // should concatenate references and literals
+        const config1 = {
+            meta: {
+                name: 'ThinkCorney',
+                version: 'v1-b1',
+                name_full: '$concat(meta.name, "-", meta.version)'
+            }
+        }
+        const unnested = p.unnest(config1)
+        const result1 = p.concat(unnested)
+        result1.meta.name_full.should.equal('ThinkCorney-v1-b1')
+
+        // should handle multiple references and literals
+        const config2 = {
+            a: 'foo',
+            b: 'bar',
+            c: 'baz',
+            res: '$concat(a, " and ", b, " and ", c)'
+        }
+        p.concat(config2).res.should.equal('foo and bar and baz')
+
+        // should handle nested concats
+        const config3 = {
+            a: 'foo',
+            b: 'bar',
+            res: '$concat(a, $concat("-", b))'
+        }
+        p.concat(config3).res.should.equal('foo-bar')
+
+        // should handle references to non-string values
+        const config4 = {
+            name: 'engine',
+            version: 4.0,
+            res: '$concat(name, ": ", version)'
+        }
+        p.concat(config4).res.should.equal('engine: 4')
+
+        // should throw on circular dependencies
+        const config5 = {
+            a: '$concat(b)',
+            b: '$concat(a)'
+        }
+        p.concat.bind(this, config5).should.throw('Circular dependency')
+
+        // should throw on unresolved references
+        const config6 = {
+            res: '$concat(nonexistent)'
+        }
+        p.concat.bind(this, config6).should.throw('Could not resolve reference')
+
+        // should handle mixed quotes and escaped quotes in literals
+        const config7 = {
+            res: '$concat("double", \'single\', "contains \\"quotes\\"")'
+        }
+        p.concat(config7).res.should.equal('doublesinglecontains "quotes"')
+
+        // should handle nested quotes of different types
+        const config8 = {
+            res: '$concat("it\'s a test", \'he said "hello"\')'
+        }
+        p.concat(config8).res.should.equal('it\'s a testhe said "hello"')
+
+        // should handle empty or whitespace-only arguments
+        const config9 = {
+            empty: '$concat()',
+            whitespace: '$concat( )',
+            mixed: '$concat(a, , b)',
+            a: 'foo',
+            b: 'bar'
+        }
+        const res9 = p.concat(config9)
+        res9.empty.should.equal('')
+        res9.whitespace.should.equal('')
+        res9.mixed.should.equal('foobar')
+    })
 })

--- a/test/unit/prepare.js
+++ b/test/unit/prepare.js
@@ -172,12 +172,26 @@ describe('Prepare', function() {
         }
         p.inherit(config_arr_inh).extended.should.deep.equal([1, 2])
 
-        // Inheritance of non-object/non-array types
-        const config_primitive_inh = {
+        // Inheritance of non-object/non-array types: string
+        const config_primitive_inh_string = {
             base: 'primitive',
             extended: { $extends: 'base' }
         }
-        p.inherit(config_primitive_inh).extended.should.equal('primitive')
+        p.inherit(config_primitive_inh_string).extended.should.equal('primitive')
+
+        // Inheritance of non-object/non-array types: boolean
+        const config_primitive_inh_boolean = {
+            base: true,
+            extended: { $extends: 'base' }
+        }
+        p.inherit(config_primitive_inh_boolean).extended.should.equal(true)
+
+        // Inheritance of non-object/non-array types: number
+        const config_primitive_inh_number = {
+            base: 42,
+            extended: { $extends: 'base' }
+        }
+        p.inherit(config_primitive_inh_number).extended.should.equal(42)
     })
 
     it('parameterize', function() {


### PR DESCRIPTION
This change introduces a new preprocessing function, `$concat(...)`, which allows users to concatenate strings in their Ergogen YAML configurations. It handles string literals, references, and nested `$concat` calls with circular dependency detection. Integrated into the preprocessing pipeline and verified with comprehensive unit tests.

---
*PR created automatically by Jules for task [6090615148835230543](https://jules.google.com/task/6090615148835230543) started by @ceoloide*