### PR TITLE
Implement automatic v3 to v4 configuration upgrade

### DIFF
--- a/src/ergogen.js
+++ b/src/ergogen.js
@@ -1,5 +1,6 @@
 const u = require('./utils')
 const io = require('./io')
+const upgrade = require('./upgrade')
 const prepare = require('./prepare')
 const units_lib = require('./units')
 const points_lib = require('./points')
@@ -26,9 +27,13 @@ const process = async (raw, options={}, logger=()=>{}) => {
     
     logger('Preprocessing input...')
     config = prepare.unnest(config)
+
+    config = upgrade.upgrade(config, logger)
+
     config = prepare.inherit(config)
     config = prepare.parameterize(config)
     config = prepare.concat(config)
+
     const results = {}
     if (debug) {
         results.raw = raw
@@ -39,7 +44,7 @@ const process = async (raw, options={}, logger=()=>{}) => {
         logger('Checking compatibility...')
         const engine = u.semver(config.meta.engine, 'config.meta.engine')
         if (!u.satisfies(version, engine)) {
-            throw new Error(`Current ergogen version (${version}) doesn\'t satisfy config's engine requirement (${config.meta.engine})!`)
+            throw new Error(`Current ergogen version (${version}) doesn't satisfy config's engine requirement (${config.meta.engine})!`)
         }
     }
 

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -1,0 +1,196 @@
+const u = require('./utils')
+const version = require('../package.json').version
+
+const detectV3 = (config) => {
+    if (config.meta && config.meta.engine) {
+        try {
+            const engine = u.semver(config.meta.engine)
+            if (engine.major === 3) return true
+        } catch (e) {
+            // Not a valid semver, could be old
+        }
+    }
+
+    // Structural cues for v3
+    if (config.points && config.points.zones) {
+        for (const zone of Object.values(config.points.zones)) {
+            if (zone && typeof zone === 'object' && zone.columns) {
+                for (const [col_name, col] of Object.entries(zone.columns)) {
+                    // Only check actual column objects (no dots in names after unnest)
+                    if (col_name.includes('.')) continue
+                    if (typeof col === 'object' && col !== null) {
+                        // These keys were moved to 'key' in v4
+                        if (col.stagger !== undefined || col.spread !== undefined || col.rotate !== undefined || col.origin !== undefined || col.row_overrides !== undefined) return true
+                    }
+                }
+            }
+        }
+    }
+
+    if (config.outlines && config.outlines.exports) return true
+
+    return false
+}
+
+const upgrade = (config, logger = () => {}) => {
+    if (typeof config !== 'object' || config === null) return config
+    if (!detectV3(config)) return config
+
+    logger('Ergogen v3 engine syntax was detected and it would be auto-updated. Suggest to enable debug to look at the canonical.yaml to see the result of the auto update.')
+
+    const res = u.deepcopy(config)
+
+    // 1. Meta update
+    res.meta = res.meta || {}
+    res.meta.engine = version
+
+    // 2. Points update
+    if (res.points) {
+        const processPointObj = (obj) => {
+            if (!obj || typeof obj !== 'object') return
+
+            // Fix columns in zones
+            if (obj.zones && typeof obj.zones === 'object') {
+                for (const zone of Object.values(obj.zones)) {
+                    if (zone && typeof zone === 'object' && zone.columns) {
+                        for (const [col_name, col] of Object.entries(zone.columns)) {
+                            if (col_name.includes('.')) continue
+                            if (typeof col === 'object' && col !== null) {
+                                const key_updates = {}
+                                if (col.stagger !== undefined) {
+                                    key_updates.stagger = col.stagger
+                                    delete col.stagger
+                                }
+                                if (col.spread !== undefined) {
+                                    key_updates.spread = col.spread
+                                    delete col.spread
+                                }
+                                if (col.rotate !== undefined) {
+                                    key_updates.splay = col.rotate
+                                    delete col.rotate
+                                }
+                                if (col.origin !== undefined) {
+                                    key_updates.origin = col.origin
+                                    delete col.origin
+                                }
+
+                                if (Object.keys(key_updates).length > 0) {
+                                    col.key = Object.assign(key_updates, col.key || {})
+                                }
+
+                                if (col.row_overrides) {
+                                    col.rows = col.row_overrides
+                                    delete col.row_overrides
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Fix asym
+            if (obj.asym === 'left') obj.asym = 'source'
+            if (obj.asym === 'right') obj.asym = 'clone'
+
+            // Recurse
+            for (const key of Object.keys(obj)) {
+                if (key === 'zones') continue // zones handled specially
+                if (typeof obj[key] === 'object') processPointObj(obj[key])
+            }
+        }
+        processPointObj(res.points)
+    }
+
+    // 3. Outlines update
+    if (res.outlines) {
+        const old_outlines = res.outlines
+        const new_outlines = {}
+
+        if (old_outlines.glue) {
+            new_outlines._glue = old_outlines.glue
+        }
+
+        const source_outlines = old_outlines.exports ? old_outlines.exports : old_outlines
+
+        for (const [outline_name, parts] of Object.entries(source_outlines)) {
+            if (outline_name === 'exports' || outline_name === 'glue' || outline_name.startsWith('_')) continue
+
+            const new_parts = {}
+            const parts_obj = (Array.isArray(parts) ? {...parts} : parts) || {}
+            for (let [part_name, part] of Object.entries(parts_obj)) {
+                let new_part = typeof part === 'string' ? part : u.deepcopy(part)
+                if (typeof new_part === 'object' && new_part !== null) {
+                    // anchor -> adjust
+                    if (new_part.anchor) {
+                        new_part.adjust = new_part.anchor
+                        delete new_part.anchor
+                    }
+
+                    // type -> what
+                    if (new_part.type) {
+                        new_part.what = new_part.type
+                        delete new_part.type
+                    }
+                    // keys -> rectangle with where: true
+                    if (new_part.what === 'keys') {
+                        new_part.what = 'rectangle'
+                        if (new_part.side === 'left') new_part.where = {mirrored: false}
+                        else if (new_part.side === 'right') new_part.where = {mirrored: true}
+                        else new_part.where = true
+                        delete new_part.side
+                        if (new_part.bound === undefined) new_part.bound = true
+                    }
+
+                    // asym fix
+                    if (new_part.asym === 'left') new_part.asym = 'source'
+                    if (new_part.asym === 'right') new_part.asym = 'clone'
+
+                    // rectangle alignment fix: v3 corner-aligned -> v4 center-aligned
+                    if (new_part.what === 'rectangle' && new_part.size) {
+                        const size = new_part.size
+                        let sw, sh
+                        if (Array.isArray(size)) {
+                            sw = size[0]
+                            sh = size[1]
+                        } else {
+                            sw = sh = size
+                        }
+
+                        new_part.adjust = new_part.adjust || {}
+                        const shift = [
+                            typeof sw === 'number' ? sw / 2 : '(' + sw + ') / 2',
+                            typeof sh === 'number' ? sh / 2 : '(' + sh + ') / 2'
+                        ]
+
+                        if (new_part.adjust.shift) {
+                            const old_shift = new_part.adjust.shift
+                            if (Array.isArray(old_shift)) {
+                                new_part.adjust.shift = [
+                                    '(' + old_shift[0] + ') + ' + shift[0],
+                                    '(' + old_shift[1] + ') + ' + shift[1]
+                                ]
+                            } else {
+                                new_part.adjust.shift = [
+                                    '(' + old_shift + ') + ' + shift[0],
+                                    shift[1]
+                                ]
+                            }
+                        } else {
+                            new_part.adjust.shift = shift
+                        }
+                    }
+                }
+                new_parts[part_name] = new_part
+            }
+            new_outlines[outline_name] = new_parts
+        }
+        res.outlines = new_outlines
+    }
+
+    return res
+}
+
+module.exports = {
+    detectV3,
+    upgrade
+}

--- a/test/unit/upgrade.js
+++ b/test/unit/upgrade.js
@@ -1,0 +1,154 @@
+const upgrade = require('../../src/upgrade')
+const chai = require('chai')
+chai.should()
+
+describe('Upgrade', function() {
+    it('should detect v3 configs correctly', function() {
+        upgrade.detectV3({meta: {engine: '3.1.2'}}).should.be.true
+        upgrade.detectV3({points: {zones: {z: {columns: {c: {stagger: 5}}}}}}).should.be.true
+        upgrade.detectV3({outlines: {exports: {}}}).should.be.true
+        upgrade.detectV3({meta: {engine: '4.0.0'}}).should.be.false
+        upgrade.detectV3({}).should.be.false
+    })
+
+    it('should upgrade points zones correctly', function() {
+        const v3 = {
+            points: {
+                zones: {
+                    main: {
+                        columns: {
+                            col1: {
+                                stagger: 5,
+                                spread: 19,
+                                rotate: 10,
+                                origin: [0, 0]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        const v4 = upgrade.upgrade(v3)
+        v4.points.zones.main.columns.col1.should.not.have.property('stagger')
+        v4.points.zones.main.columns.col1.should.not.have.property('spread')
+        v4.points.zones.main.columns.col1.key.stagger.should.equal(5)
+        v4.points.zones.main.columns.col1.key.spread.should.equal(19)
+        v4.points.zones.main.columns.col1.key.splay.should.equal(10)
+        v4.points.zones.main.columns.col1.key.origin.should.deep.equal([0, 0])
+    })
+
+    it('should fix asym values', function() {
+        const v3 = {
+            points: {
+                key: { asym: 'left' }
+            },
+            outlines: {
+                exports: {
+                    main: {
+                        p1: { asym: 'right' }
+                    }
+                }
+            }
+        }
+        const v4 = upgrade.upgrade(v3)
+        v4.points.key.asym.should.equal('source')
+        v4.outlines.main.p1.asym.should.equal('clone')
+    })
+
+    it('should flat outlines.exports and fix type/what', function() {
+        const v3 = {
+            outlines: {
+                exports: {
+                    main: {
+                        part1: { type: 'rectangle', size: 10 }
+                    }
+                }
+            }
+        }
+        const v4 = upgrade.upgrade(v3)
+        v4.outlines.should.have.property('main')
+        v4.outlines.main.part1.should.have.property('what', 'rectangle')
+        v4.outlines.main.part1.should.not.have.property('type')
+    })
+
+    it('should map type: keys to what: rectangle with where: true', function() {
+        const v3 = {
+            outlines: {
+                exports: {
+                    main: {
+                        part1: { type: 'keys', size: 18 }
+                    }
+                }
+            }
+        }
+        const v4 = upgrade.upgrade(v3)
+        v4.outlines.main.part1.what.should.equal('rectangle')
+        v4.outlines.main.part1.where.should.equal(true)
+        v4.outlines.main.part1.bound.should.equal(true)
+    })
+
+    it('should adjust rectangle shift for center-alignment', function() {
+        const v3 = {
+            outlines: {
+                exports: {
+                    main: {
+                        part1: { type: 'rectangle', size: [10, 20] }
+                    }
+                }
+            }
+        }
+        const v4 = upgrade.upgrade(v3)
+        v4.outlines.main.part1.adjust.shift.should.deep.equal([5, 10])
+    })
+
+    it('should handle formula sizes for rectangle alignment', function() {
+        const v3 = {
+            outlines: {
+                exports: {
+                    main: {
+                        part1: { type: 'rectangle', size: ['u', 'u+2'] }
+                    }
+                }
+            }
+        }
+        const v4 = upgrade.upgrade(v3)
+        v4.outlines.main.part1.adjust.shift.should.deep.equal(['(u) / 2', '(u+2) / 2'])
+    })
+
+    it('should handle complex real test case', function() {
+        const v3 = {
+            points: {
+                zones: {
+                    board: {
+                        columns: {
+                            pinkie: {
+                                rotate: 30,
+                                row_overrides: {
+                                    home: { column_net: 'P1' }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            outlines: {
+                exports: {
+                    raw: [
+                        { type: 'keys', side: 'left', size: ['1cx', '1cy'] }
+                    ],
+                    cutouta: [
+                        { type: 'outline', name: 'raw', fillet: 2 }
+                    ]
+                }
+            }
+        }
+        const v4 = upgrade.upgrade(v3)
+        v4.points.zones.board.columns.pinkie.key.splay.should.equal(30)
+        v4.points.zones.board.columns.pinkie.rows.home.column_net.should.equal('P1')
+        v4.outlines.raw[0].what.should.equal('rectangle')
+        v4.outlines.raw[0].where.should.deep.equal({mirrored: false})
+        v4.outlines.raw[0].adjust.shift.should.deep.equal(['(1cx) / 2', '(1cy) / 2'])
+        v4.outlines.cutouta[0].what.should.equal('outline')
+        v4.outlines.cutouta[0].name.should.equal('raw')
+    })
+})


### PR DESCRIPTION
This PR adds automatic version detection and upgrade logic to Ergogen. It detects configurations written for the v3 engine (specifically v3.1.2 and earlier) and migrates them to the v4 syntax before processing. 

Key migrations:
- **Points**: Moves column-level attributes (`stagger`, `spread`, `rotate`, `origin`) into the `key` block and renames `rotate` to `splay`.
- **Outlines**: Converts the v3 `exports` structure into the flat v4 structure, renames `type` to `what`, and maps `type: keys` to a rectangle with `where: true`.
- **Rectangle Alignment**: Automatically adds an `adjust.shift` to v3 rectangles to account for the transition from corner-aligned (v3) to center-aligned (v4).
- **Metadata**: Automatically updates `meta.engine` to the current version.

Includes comprehensive unit tests in `test/unit/upgrade.js`.

---
*PR created automatically by Jules for task [5417987842521934793](https://jules.google.com/task/5417987842521934793) started by @ceoloide*